### PR TITLE
rust: replace pushd usage in rust do_install

### DIFF
--- a/recipes/rust/rust.inc
+++ b/recipes/rust/rust.inc
@@ -358,9 +358,7 @@ rust_do_install () {
 
         ## rust will complain about multiple providers of the runtime libs
         ## (libstd, libsync, etc.) without this.
-        pushd "${D}${libdir}"
-        ln -sf "rustlib/${HOST_SYS}/lib/lib"*.so .
-        popd
+        (cd "${D}${libdir}" && ln -sf "rustlib/${HOST_SYS}/lib/lib"*.so .)
 }
 
 do_install () {


### PR DESCRIPTION
In dizzy, the following error was encountered when running do_install
on the rust recipe:

    pushd: not found

According to the bitbake user manual, /bin/sh is used and bashisms
(like pushd) should be avoided.  In my case, /bin/sh turns out to
be zsh (with no extra configuration, so pushd is not present).

Signed-off-by: Paul Osborne <osbpau@gmail.com>