### PR TITLE
libgit2: dizzy: tell cmake to use ${AR} for the linker

### DIFF
--- a/recipes-deps/libgit2/libgit2.inc
+++ b/recipes-deps/libgit2/libgit2.inc
@@ -22,4 +22,15 @@ EXTRA_OECMAKE = "\
 
 CFLAGS_append .= " -fPIC"
 
+# Prior to poky commit 60d504b431fa7cdc6ded141def7ae18edb1834e5,
+# the cmake class did not define CMAKE_AR in the generated toolchain
+# file.  This is needed to support building a static library.
+# See https://github.com/jmesmon/meta-rust/issues/1
+OECMAKE_AR ?= "${AR}"
+cmake_do_generate_toolchain_file_append() {
+    cat >> ${WORKDIR}/toolchain.cmake <<EOF
+set( CMAKE_AR ${OECMAKE_AR} CACHE FILEPATH "Archiver" )
+EOF
+}
+
 BBCLASSEXTEND = "native"


### PR DESCRIPTION
This resolves https://github.com/jmesmon/meta-rust/issues/1.  This
change is only necessary for systems (like dizzy) that do not
contain poky commit 60d504b431fa7cdc6ded141def7ae18edb1834e5.

Without that commit or this change, do_compile for libgit2 would fail
with the following error:

    CMAKE_AR-NOTFOUND cr libgit2.a  ...
    Error running link command: No such file or directory

Signed-off-by: Paul Osborne <osbpau@gmail.com>