### PR TITLE
Make LLVM in its own recipe

### DIFF
--- a/recipes/rust/rust-llvm-native_1.1.0.bb
+++ b/recipes/rust/rust-llvm-native_1.1.0.bb
@@ -1,0 +1,27 @@
+SUMMARY = "LLVM compiler framework (packaged with rust)"
+LICENSE = "NCSA"
+
+LIC_FILES_CHKSUM = "file://LICENSE.TXT;md5=47e311aa9caedd1b3abf098bd7814d1d"
+
+# 1.1.0
+require rust-release.inc
+SRC_URI[rust.md5sum] = "5f2f923f8d1c77a55721d1f0813a158a"
+SRC_URI[rust.sha256sum] = "cb09f443b37ec1b81fe73c04eb413f9f656859cf7d00bc5088008cbc2a63fa8a"
+
+S = "${WORKDIR}/rustc-${PV}/src/llvm"
+
+inherit autotools
+inherit native
+
+EXTRA_OECONF += "--enable-targets=x86,x86_64,arm,aarch64,mips,powerpc"
+EXTRA_OECONF += "--enable-optimized"
+EXTRA_OECONF += "--disable-bindings"
+
+do_install_append () {
+	cd ${D}${bindir}
+	ln -s *-llc llc
+	for i in *-llvm-*; do
+		link=$(echo $i | sed -e 's/.*-llvm-\(.*\)/\1/')
+		ln -s $i llvm-$link
+	done
+}

--- a/recipes/rust/rust-release.inc
+++ b/recipes/rust/rust-release.inc
@@ -3,5 +3,4 @@ SRC_URI = "\
 "
 
 S = "${WORKDIR}/rustc-${PV}"
-require rust.inc
 

--- a/recipes/rust/rust.inc
+++ b/recipes/rust/rust.inc
@@ -8,6 +8,9 @@ LICENSE = "MIT | Apache-2.0"
 
 B = "${WORKDIR}/build"
 
+DEPENDS += "rust-llvm-native"
+DEPENDS_class-cross += "rust-llvm-native"
+
 # Avoid having the default bitbake.conf disable sub-make parallelization
 EXTRA_OEMAKE = ""
 
@@ -272,6 +275,8 @@ python do_rust_arch_fixup () {
 addtask rust_arch_fixup before do_configure after do_patch
 do_rust_arch_fixup[dirs] = "${S}/mk/cfg"
 
+llvmdir = "${STAGING_DIR_NATIVE}/${prefix_native}"
+
 do_configure () {
 	# FIXME: target_prefix vs prefix, see cross.bbclass
 
@@ -309,7 +314,7 @@ do_configure () {
 		"--enable-debuginfo"			\
 		"--enable-optimize"			\
 		"--enable-optimize-cxx"			\
-		"--enable-optimize-llvm"		\
+		"--llvm-root=${llvmdir}"		\
 		"--enable-optimize-tests"		\
 		"--prefix=${prefix}"			\
 		"--target=${TARGET_SYS}"		\

--- a/recipes/rust/rust.inc
+++ b/recipes/rust/rust.inc
@@ -306,6 +306,7 @@ do_configure () {
 		"--disable-docs"			\
 		"--disable-manage-submodules"           \
 		"--disable-debug"			\
+		"--enable-debuginfo"			\
 		"--enable-optimize"			\
 		"--enable-optimize-cxx"			\
 		"--enable-optimize-llvm"		\

--- a/recipes/rust/rust_1.1.0.bb
+++ b/recipes/rust/rust_1.1.0.bb
@@ -1,5 +1,6 @@
 # 1.1.0
 require rust-release.inc
+require rust.inc
 SRC_URI[rust.md5sum] = "5f2f923f8d1c77a55721d1f0813a158a"
 SRC_URI[rust.sha256sum] = "cb09f443b37ec1b81fe73c04eb413f9f656859cf7d00bc5088008cbc2a63fa8a"
 


### PR DESCRIPTION
rust takes a painfully long time to build.  A non-trivial part of that
is building LLVM.  Fortuitiously, the LLVM component is common between
the -native compiler and all variants of the -cross compiler.  That
means we can build it once, and reuse the output for any flavor of rust.
That saves build time, and it utilizes bitbake's sstate more
efficiently.  It's win/win!
