### PR TITLE
Disable symbol hashing

### DIFF
--- a/recipes/rust/files/rust-1.1.0/0009-src-rt-arch-i386-morestack.S-call-rust_stack_exhaust.patch
+++ b/recipes/rust/files/rust-1.1.0/0009-src-rt-arch-i386-morestack.S-call-rust_stack_exhaust.patch
@@ -1,0 +1,47 @@
+From 02936deefb786a244c98ec2293e6b85ecfc85cdb Mon Sep 17 00:00:00 2001
+From: Steven Walter <swalter@lexmark.com>
+Date: Mon, 15 Jun 2015 11:35:47 -0400
+Subject: [PATCH] src/rt/arch/i386/morestack.S: call rust_stack_exhausted via
+ plt
+
+This prevents a relocation in the text section.  Text relocations are
+incompatible with hardened kernels.
+
+https://github.com/rust-lang/rust/issues/5714
+---
+ src/rt/arch/i386/morestack.S | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/src/rt/arch/i386/morestack.S b/src/rt/arch/i386/morestack.S
+index 2f03251..98fdfdf 100644
+--- a/src/rt/arch/i386/morestack.S
++++ b/src/rt/arch/i386/morestack.S
+@@ -75,7 +75,7 @@
+ #else
+ #if defined(__linux__) || defined(__FreeBSD__)
+ #define MORESTACK               __morestack
+-#define EXHAUSTED               rust_stack_exhausted
++#define EXHAUSTED               rust_stack_exhausted@plt
+ #else
+ #define MORESTACK               ___morestack
+ #define EXHAUSTED               _rust_stack_exhausted
+@@ -83,7 +83,6 @@
+ #endif
+ 
+ .globl MORESTACK
+-.globl EXHAUSTED
+ 
+ // FIXME: What about __WIN32__?
+ #if defined(__linux__) || defined(__FreeBSD__)
+@@ -138,7 +137,7 @@ MORESTACK:
+ 
+         // re-align the stack
+         subl $12,%esp
+-        calll EXHAUSTED
++        call EXHAUSTED
+         // the exhaustion function guarantees that it can't return
+ 
+ 	.cfi_endproc
+-- 
+1.9.1
+

--- a/recipes/rust/files/rust-1.1.0/0010-disable-symbol-version-hashing.patch
+++ b/recipes/rust/files/rust-1.1.0/0010-disable-symbol-version-hashing.patch
@@ -1,0 +1,26 @@
+From 9db9d253355cc0e9e885bb1e63b054e318f9395a Mon Sep 17 00:00:00 2001
+From: Steven Walter <swalter@lexmark.com>
+Date: Tue, 7 Jul 2015 14:57:42 -0400
+Subject: [PATCH] Remove crate metadata from symbol hashing
+
+---
+ src/librustc_trans/back/link.rs | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/src/librustc_trans/back/link.rs b/src/librustc_trans/back/link.rs
+index 2f2ba16..ea3e897 100644
+--- a/src/librustc_trans/back/link.rs
++++ b/src/librustc_trans/back/link.rs
+@@ -205,9 +205,4 @@ fn symbol_hash<'tcx>(tcx: &ty::ctxt<'tcx>,
+     symbol_hasher.input_str(&link_meta.crate_name);
+-    symbol_hasher.input_str("-");
+-    symbol_hasher.input_str(link_meta.crate_hash.as_str());
+-    for meta in &*tcx.sess.crate_metadata.borrow() {
+-        symbol_hasher.input_str(&meta[..]);
+-    }
+     symbol_hasher.input_str("-");
+     symbol_hasher.input_str(&encoder::encoded_ty(tcx, t));
+     // Prefix with 'h' so that it never blends into adjacent digits
+-- 
+1.9.1
+

--- a/recipes/rust/rust_1.1.0.bb
+++ b/recipes/rust/rust_1.1.0.bb
@@ -27,6 +27,7 @@ SRC_URI_append = "\
 	file://${PP}/0006-std-thread_local-workaround-for-NULL-__dso_handle.patch \
 	file://${PP}/0007-mk-install-use-disable-rewrite-paths.patch \
 	file://${PP}/0008-install-disable-ldconfig.patch \
+	file://${PP}/0009-src-rt-arch-i386-morestack.S-call-rust_stack_exhaust.patch \
 \
 	file://rust-installer/0001-add-option-to-disable-rewriting-of-install-paths.patch;patchdir=src/rust-installer \
 "

--- a/recipes/rust/rust_1.1.0.bb
+++ b/recipes/rust/rust_1.1.0.bb
@@ -28,6 +28,7 @@ SRC_URI_append = "\
 	file://${PP}/0007-mk-install-use-disable-rewrite-paths.patch \
 	file://${PP}/0008-install-disable-ldconfig.patch \
 	file://${PP}/0009-src-rt-arch-i386-morestack.S-call-rust_stack_exhaust.patch \
+	file://${PP}/0010-disable-symbol-version-hashing.patch \
 \
 	file://rust-installer/0001-add-option-to-disable-rewriting-of-install-paths.patch;patchdir=src/rust-installer \
 "


### PR DESCRIPTION
Rust's symbol hashes break sstate, because a subsequent build of the same
input hash may generate different symbol hashes.  This means that
packages that previously built against the "same" (from bitbake's
perspective) rustc would no longer run, and bitbake would not know to
rebuild them because the input hash is the same.

Fortunately, bitbake's input hash makes rust's symbol versions
unnecessary; any change to rust's source or configuration will cause
rustc and all dependencies to rebuild.  Therefore, it's safe to defeat
rust's symbol versions entirely with a static version.