### PR TITLE
rust-llvm.inc: fix configure flags to match was rust uses

### DIFF
--- a/recipes/rust/rust-llvm.inc
+++ b/recipes/rust/rust-llvm.inc
@@ -8,7 +8,9 @@ inherit autotools
 
 EXTRA_OECONF += "--enable-targets=x86,x86_64,arm,aarch64,mips,powerpc"
 EXTRA_OECONF += "--enable-optimized"
-EXTRA_OECONF += "--disable-bindings"
+EXTRA_OECONF += "--disable-assertions"
+EXTRA_OECONF += "--disable-docs"
+EXTRA_OECONF += "--enable-bindings=none"
 EXTRA_OECONF += "--enable-keep-symbols"
 
 do_install_append () {


### PR DESCRIPTION
This fixes the assertion failure and allows 1.2.0 to successfully build