### PR TITLE
fix LICENSE_PATH location

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,4 +8,4 @@ BBFILE_COLLECTIONS += "rust-layer"
 BBFILE_PATTERN_rust-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_rust-layer = "7"
 
-LICENSE_PATH += "${LAYERDIR}/files/licenses"
+LICENSE_PATH += "${LAYERDIR}/files/common-licenses"


### PR DESCRIPTION
The path in LICENSE_PATH was not the correct path to where the licenses
are located in this repo.

Signed-off-by: Doug Goldstein <cardoe@cardoe.com>