### PR TITLE
remove conf/licenses.conf

### DIFF
--- a/conf/licenses.conf
+++ b/conf/licenses.conf
@@ -1,1 +1,0 @@
-SRC_DISTRIBUTE_LICENSES += "GPL-2.0-with-linking-exception"


### PR DESCRIPTION
Per conversation in #rust with kergoth this file is causing a backtrace
in bitbake because its overriding the meta/conf/licenses.conf file. The
behavior that's expected out of this isn't valid with newer Yocto
releases so its possible this is for an older version.

Signed-off-by: Doug Goldstein <cardoe@cardoe.com>