### PR TITLE
Provide distro config include for security flags

### DIFF
--- a/conf/distro/include/rust_security_flags.inc
+++ b/conf/distro/include/rust_security_flags.inc
@@ -1,0 +1,4 @@
+# Build errors with PIE options enabled
+SECURITY_CFLAGS_pn-rust-native = "${SECURITY_NO_PIE_CFLAGS}"
+SECURITY_CFLAGS_pn-rust-cross = "${SECURITY_NO_PIE_CFLAGS}"
+SECURITY_CFLAGS_pn-rust = "${SECURITY_NO_PIE_CFLAGS}"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,3 +9,6 @@ BBFILE_PATTERN_rust-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_rust-layer = "7"
 
 LICENSE_PATH += "${LAYERDIR}/files/licenses"
+
+# Override security flags
+require conf/distro/include/rust_security_flags.inc


### PR DESCRIPTION
When someone is using a distro that's using security flags we need to
provide overrides to disable PIE.

Signed-off-by: Doug Goldstein <cardoe@cardoe.com>