### PR TITLE
rust: force crate hash to use bitbake input hash

### DIFF
--- a/classes/rust.bbclass
+++ b/classes/rust.bbclass
@@ -1,7 +1,7 @@
 RUSTC = "rustc"
 
 # FIXME: --sysroot might be needed
-RUSTC_ARCHFLAGS += "--target=${TARGET_SYS} -C rpath"
+RUSTC_ARCHFLAGS += "--target=${TARGET_SYS} -C rpath -C crate_hash=${BB_TASKHASH}"
 
 def rust_base_dep(d):
     # Taken from meta/classes/base.bbclass `base_dep_prepend` and modified to

--- a/recipes/rust/files/rust-1.5.0/0011-Allow-overriding-crate_hash-with-C-crate_hash.patch
+++ b/recipes/rust/files/rust-1.5.0/0011-Allow-overriding-crate_hash-with-C-crate_hash.patch
@@ -1,0 +1,78 @@
+From 128a81ede6b188637743a37a582b2267a49d0a32 Mon Sep 17 00:00:00 2001
+From: Steven Walter <swalter@lexmark.com>
+Date: Wed, 18 Nov 2015 08:33:26 -0500
+Subject: [PATCH 11/12] Allow overriding crate_hash with -C crate_hash
+
+The current crate hash is not stable from run-to-run.  This causes
+problems with bitbake; it needs a guarantee that every build with the
+same input will generate compatible output, otherwise sstate won't work.
+Using -C crate_hash, we can do that by using the bitbake input hash to
+determine the crate hash; the bitbake input hash will be stable, but
+still different for different rust recipes.
+---
+ src/librustc/session/config.rs  |  2 ++
+ src/librustc_trans/back/link.rs | 26 ++++++++++++++++++++++++--
+ 2 files changed, 26 insertions(+), 2 deletions(-)
+
+diff --git a/src/librustc/session/config.rs b/src/librustc/session/config.rs
+index b74b3c4..a11cb90 100644
+--- a/src/librustc/session/config.rs
++++ b/src/librustc/session/config.rs
+@@ -500,6 +500,8 @@ options! {CodegenOptions, CodegenSetter, basic_codegen_options,
+          "choose the code model to use (llc -code-model for details)"),
+     metadata: Vec<String> = (Vec::new(), parse_list,
+          "metadata to mangle symbol names with"),
++    crate_hash: String = ("".to_string(), parse_string,
++         "override crate hash with given value"),
+     extra_filename: String = ("".to_string(), parse_string,
+          "extra data to put in each output filename"),
+     codegen_units: usize = (1, parse_uint,
+diff --git a/src/librustc_trans/back/link.rs b/src/librustc_trans/back/link.rs
+index 53fa913..83619ae 100644
+--- a/src/librustc_trans/back/link.rs
++++ b/src/librustc_trans/back/link.rs
+@@ -46,7 +46,7 @@ use std::str;
+ use flate;
+ use serialize::hex::ToHex;
+ use syntax::ast;
+-use syntax::codemap::Span;
++use syntax::codemap::{Span,BytePos,NO_EXPANSION};
+ use syntax::parse::token::{self, InternedString};
+ use syntax::attr::AttrMetaMethods;
+ 
+@@ -185,9 +185,31 @@ pub fn find_crate_name(sess: Option<&Session>,
+ 
+ pub fn build_link_meta(sess: &Session, krate: &hir::Crate,
+                        name: &str) -> LinkMeta {
++    let crate_hash = if sess.opts.cg.crate_hash != "" {
++        let dummy_span = Span {
++            lo: BytePos(0),
++            hi: BytePos(0),
++            expn_id: NO_EXPANSION
++        };
++        let dummy_module = hir::Mod {
++            inner: dummy_span,
++            items: vec!()
++        };
++        let dummy_krate = hir::Crate {
++            module: dummy_module,
++            attrs: vec!(),
++            config: vec!(),
++            span: dummy_span,
++            exported_macros: vec!()
++        };
++
++        Svh::calculate(&vec!(sess.opts.cg.crate_hash.clone()), &dummy_krate)
++    } else {
++        Svh::calculate(&sess.opts.cg.metadata, krate)
++    };
+     let r = LinkMeta {
+         crate_name: name.to_owned(),
+-        crate_hash: Svh::calculate(&sess.opts.cg.metadata, krate),
++        crate_hash: crate_hash,
+     };
+     info!("{:?}", r);
+     return r;
+-- 
+1.9.1
+

--- a/recipes/rust/files/rust-1.5.0/0012-mk-platform.mk-pass-C-crate_hash-to-builds.patch
+++ b/recipes/rust/files/rust-1.5.0/0012-mk-platform.mk-pass-C-crate_hash-to-builds.patch
@@ -1,0 +1,25 @@
+From d0fa41075317425b01262dd539c01e87e2eaf5f4 Mon Sep 17 00:00:00 2001
+From: Steven Walter <swalter@lexmark.com>
+Date: Wed, 18 Nov 2015 08:41:17 -0500
+Subject: [PATCH 12/12] mk/platform.mk: pass -C crate_hash to builds
+
+bitbake recipe will export FORCE_CRATE_HASH
+---
+ mk/platform.mk | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/mk/platform.mk b/mk/platform.mk
+index 4681783..59aa560 100644
+--- a/mk/platform.mk
++++ b/mk/platform.mk
+@@ -182,6 +182,7 @@ define CFG_MAKE_TOOLCHAIN
+        LINK_$(1)=$(CROSS_PREFIX_$(1))$(LINK_$(1))
+        RUSTC_CROSS_FLAGS_$(1)=-C linker=$$(call FIND_COMPILER,$$(LINK_$(1))) \
+            -C objcopy=$$(call FIND_COMPILER,$$(OBJCOPY_$(1))) \
++           -C crate_hash=$(FORCE_CRATE_HASH) \
+            -C ar=$$(call FIND_COMPILER,$$(AR_$(1))) $(RUSTC_CROSS_FLAGS_$(1))
+ 
+        RUSTC_FLAGS_$(1)=$$(RUSTC_CROSS_FLAGS_$(1)) $(RUSTC_FLAGS_$(1))
+-- 
+1.9.1
+

--- a/recipes/rust/rust.inc
+++ b/recipes/rust/rust.inc
@@ -29,6 +29,8 @@ SRC_URI += "${@bb.utils.contains('PACKAGECONFIG', 'local-rust', '', 'https://sta
 # We generate local targets, and need to be able to locate them
 export RUST_TARGET_PATH="${WORKDIR}/targets/"
 
+export FORCE_CRATE_HASH="${BB_TASKHASH}"
+
 ## arm-unknown-linux-gnueabihf
 DATA_LAYOUT[arm] = "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:64:128-a0:0:64-n32"
 LLVM_TARGET[arm] = "${RUST_TARGET_SYS}"

--- a/recipes/rust/rust_1.5.0.bb
+++ b/recipes/rust/rust_1.5.0.bb
@@ -15,6 +15,8 @@ SRC_URI_append = "\
         file://${PP}/0008-install-disable-ldconfig.patch \
         file://${PP}/0009-Remove-crate-metadata-from-symbol-hashing.patch \
         file://${PP}/0010-rustc_trans-make-.note.rustc-look-more-like-debug-in.patch \
+        file://${PP}/0011-Allow-overriding-crate_hash-with-C-crate_hash.patch \
+        file://${PP}/0012-mk-platform.mk-pass-C-crate_hash-to-builds.patch \
 \
 	file://rust-installer/0001-add-option-to-disable-rewriting-of-install-paths.patch;patchdir=src/rust-installer \
 "


### PR DESCRIPTION
The current crate hash is not stable from run-to-run.  This causes
problems with bitbake; it needs a guarantee that every build with the
same input will generate compatible output, otherwise sstate won't work.
Using -C crate_hash, we can do that by using the bitbake input hash to
determine the crate hash; the bitbake input hash will be stable, but
still different for different rust recipes.

This should eliminate the problems that have been seen when bitbake
rebuilds part of the rust stack (due to missing sstate) and ends up
getting hash mismatches.  Unlike rust's internally generated hash, ours
is guaranteed to be stable.