### PR TITLE
Remove the '--disable-static' in the EXTRA_OECONF for all rust-like recipes

### DIFF
--- a/classes/rust.bbclass
+++ b/classes/rust.bbclass
@@ -82,3 +82,5 @@ HOST_LDFLAGS  ?= "${LDFLAGS}"
 HOST_CFLAGS   ?= "${CFLAGS}"
 HOST_CXXFLAGS ?= "${CXXFLAGS}"
 HOST_CPPFLAGS ?= "${CPPFLAGS}"
+
+EXTRA_OECONF_remove = "--disable-static"


### PR DESCRIPTION
Remove the newly introduced (in poky) --disable-static which is not recognized by the rust configure scripts.

Fixes #40 