### PR TITLE
Add libssh2 recipe from openembedded

### DIFF
--- a/recipes-deps/libssh2/libssh2_1.6.0.bb
+++ b/recipes-deps/libssh2/libssh2_1.6.0.bb
@@ -1,0 +1,24 @@
+SUMMARY = "A client-side C library implementing the SSH2 protocol"
+HOMEPAGE = "http://www.libssh2.org/"
+SECTION = "libs"
+
+DEPENDS = "zlib"
+
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://COPYING;md5=c5cf34fc0acb44b082ef50ef5e4354ca"
+
+SRC_URI = "http://www.libssh2.org/download/${BP}.tar.gz"
+SRC_URI[md5sum] = "00aabd6e714a5f42a4fb82ace20db1dd"
+SRC_URI[sha256sum] = "5a202943a34a1d82a1c31f74094f2453c207bf9936093867f41414968c8e8215"
+
+inherit autotools pkgconfig
+
+EXTRA_OECONF += "\
+                 --with-libz \
+                 --with-libz-prefix=${STAGING_LIBDIR} \
+                "
+
+# only one of openssl and gcrypt could be set
+PACKAGECONFIG ??= "openssl"
+PACKAGECONFIG[openssl] = "--with-openssl --with-libssl-prefix=${STAGING_LIBDIR},--without-openssl,openssl"
+PACKAGECONFIG[gcrypt] = "--with-libgcrypt --with-libgcrypt-prefix=${STAGING_EXECPREFIXDIR},--without-libgcrypt,libgcrypt"


### PR DESCRIPTION
The libssh2 recipe isn't in Poky/Jethro. Import it into meta-rust so meta-rust
only depends on Poky.

This code was taken from the jethro branch of poky, commit ID
c305ac5d2f5285d5eec8952a4ca7f3b4f89aed96