### PR TITLE
Several fixes for rust 1.7

### DIFF
--- a/classes/rust-bin.bbclass
+++ b/classes/rust-bin.bbclass
@@ -34,7 +34,8 @@ OVERLAP_DEPS = "${@get_overlap_deps(d)}"
 
 # Prevents multiple static copies of standard library modules
 # See https://github.com/rust-lang/rust/issues/19680
-RUSTC_FLAGS += "-C prefer-dynamic"
+RUSTC_PREFER_DYNAMIC = "-C prefer-dynamic"
+RUSTC_FLAGS += "${RUSTC_PREFER_DYNAMIC}"
 
 rustlib_suffix="${TUNE_ARCH}${TARGET_VENDOR}-${TARGET_OS}/rustlib/${HOST_SYS}/lib"
 # Native sysroot standard library path

--- a/recipes-core/libc/libc-rs_0.2.5.bb
+++ b/recipes-core/libc/libc-rs_0.2.5.bb
@@ -2,20 +2,18 @@ DESCRIPTION = "A Rust library with native bindings to the types and functions co
 HOMEPAGE = "https://github.com/rust-lang/libc"
 LICENSE = "MIT | Apache-2.0"
 LIC_FILES_CHKSUM = "\
-	file://LICENSE-MIT;md5=615cc94ba6f721c4ed3d6988605e85ca \
+	file://LICENSE-MIT;md5=362255802eb5aa87810d12ddf3cfedb4 \
 	file://LICENSE-APACHE;md5=1836efb2eb779966696f473ee8540542 \
 "
 
 inherit rust-bin
 
-# SRC_URI = "git://git@github.com:rust-lang/libc.git;protocol=https"
-# libc lives in rust-lang/rust which is a submodule of rust-lang/libc
-SRC_URI = "gitsm://github.com/rust-lang/rust.git;protocol=https"
-SRCREV = "8b7c17db2235a2a3f2c71242b11fc429a8d05a90"
+SRC_URI = "git://github.com/rust-lang/libc.git;protocol=https"
+SRCREV = "f54b9c90ee68889181472d4d4a5dd9e43d0e5318"
 
 S = "${WORKDIR}/git"
 
-LIB_SRC = "${S}/src/liblibc/lib.rs"
+LIB_SRC = "${S}/src/lib.rs"
 
 do_compile () {
 	oe_compile_rust_lib --cfg feature='"cargo-build"'

--- a/recipes-devtools/rust/files/rust/0001-Add-config-for-musl-based-arm-builds.patch
+++ b/recipes-devtools/rust/files/rust/0001-Add-config-for-musl-based-arm-builds.patch
@@ -1,0 +1,45 @@
+From 185c77dbb5708bed7c916b8e01ff867b6c215bfb Mon Sep 17 00:00:00 2001
+From: Steven Walter <swalter@lexmark.com>
+Date: Mon, 2 May 2016 19:57:46 -0400
+Subject: [PATCH] Add config for musl-based arm builds
+
+---
+ mk/cfg/arm-unknown-linux-musleabi.mk | 26 ++++++++++++++++++++++++++
+ 1 file changed, 26 insertions(+)
+ create mode 100644 mk/cfg/arm-unknown-linux-musleabi.mk
+
+diff --git a/mk/cfg/arm-unknown-linux-musleabi.mk b/mk/cfg/arm-unknown-linux-musleabi.mk
+new file mode 100644
+index 0000000..2485bd9
+--- /dev/null
++++ b/mk/cfg/arm-unknown-linux-musleabi.mk
+@@ -0,0 +1,26 @@
++# arm-unknown-linux-musleabi configuration
++CROSS_PREFIX_arm-unknown-linux-musleabi=arm-linux-musleabi-
++CC_arm-unknown-linux-musleabi=gcc
++CXX_arm-unknown-linux-musleabi=g++
++CPP_arm-unknown-linux-musleabi=gcc -E
++AR_arm-unknown-linux-musleabi=ar
++CFG_LIB_NAME_arm-unknown-linux-musleabi=lib$(1).so
++CFG_STATIC_LIB_NAME_arm-unknown-linux-musleabi=lib$(1).a
++CFG_LIB_GLOB_arm-unknown-linux-musleabi=lib$(1)-*.so
++CFG_LIB_DSYM_GLOB_arm-unknown-linux-musleabi=lib$(1)-*.dylib.dSYM
++CFG_JEMALLOC_CFLAGS_arm-unknown-linux-musleabi := -D__arm__ $(CFLAGS)
++CFG_GCCISH_CFLAGS_arm-unknown-linux-musleabi := -Wall -g -fPIC -D__arm__ $(CFLAGS)
++CFG_GCCISH_CXXFLAGS_arm-unknown-linux-musleabi := -fno-rtti $(CXXFLAGS)
++CFG_GCCISH_LINK_FLAGS_arm-unknown-linux-musleabi := -shared -fPIC -g
++CFG_GCCISH_DEF_FLAG_arm-unknown-linux-musleabi := -Wl,--export-dynamic,--dynamic-list=
++CFG_LLC_FLAGS_arm-unknown-linux-musleabi :=
++CFG_INSTALL_NAME_arm-unknown-linux-musleabi =
++CFG_EXE_SUFFIX_arm-unknown-linux-musleabi :=
++CFG_WINDOWSY_arm-unknown-linux-musleabi :=
++CFG_UNIXY_arm-unknown-linux-musleabi := 1
++CFG_LDPATH_arm-unknown-linux-musleabi :=
++CFG_RUN_arm-unknown-linux-musleabi=$(2)
++CFG_RUN_TARG_arm-unknown-linux-musleabi=$(call CFG_RUN_arm-unknown-linux-musleabi,,$(2))
++RUSTC_FLAGS_arm-unknown-linux-musleabi :=
++RUSTC_CROSS_FLAGS_arm-unknown-linux-musleabi :=
++CFG_GNU_TRIPLE_arm-unknown-linux-musleabi := arm-unknown-linux-musleabi
+-- 
+2.7.4
+

--- a/recipes-devtools/rust/rust-snapshot-2015-12-18.inc
+++ b/recipes-devtools/rust/rust-snapshot-2015-12-18.inc
@@ -1,14 +1,14 @@
 ## snapshot info taken from rust/src/snapshots.txt
 ## TODO: find a way to add additional SRC_URIs based on the contents of an
 ##       earlier SRC_URI.
-RS_DATE = "2015-08-11"
-RS_SRCHASH = "1af31d4"
+RS_DATE = "2015-12-18"
+RS_SRCHASH = "3391630"
 # linux-x86_64
 RS_ARCH = "linux-x86_64"
-RS_HASH = "7df8ba9dec63ec77b857066109d4b6250f3d222f"
+RS_HASH = "97e2a5eb8904962df8596e95d6e5d9b574d73bf4"
 
 RUST_SNAPSHOT = "rust-stage0-${RS_DATE}-${RS_SRCHASH}-${RS_ARCH}-${RS_HASH}.tar.bz2"
 
-SRC_URI[rust-snapshot.md5sum] = "53b2e1f553eaeb88e8d60d5380670283"
-SRC_URI[rust-snapshot.sha256sum] = "5936f5ec4327d41f3aa9f98cbedebb6fd3d72715f8df578e0c9a669154c80bc3"
+SRC_URI[rust-snapshot.md5sum] = "5c29eb06c8b6ce6ff52f544f31efabe1"
+SRC_URI[rust-snapshot.sha256sum] = "a8dc5203673ce43f47316beb02ee0c427edb7bbde2ab5fc662a06b52db2950e7"
 

--- a/recipes-devtools/rust/rust-source.bb
+++ b/recipes-devtools/rust/rust-source.bb
@@ -27,4 +27,5 @@ SRC_URI_append = "\
         file://rust/0013-mk-allow-changing-the-platform-configuration-source-.patch \
         file://rust-llvm/0000-rust-llvm-remove-extra-slash.patch \
         file://rust-installer/0001-add-option-to-disable-rewriting-of-install-paths.patch;patchdir=src/rust-installer \
+        file://rust/0001-Add-config-for-musl-based-arm-builds.patch \
 "

--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -2,7 +2,7 @@
 inherit rust
 inherit rust-installer
 require rust-shared-source.inc
-require rust-snapshot-2015-08-11.inc
+require rust-snapshot-2015-12-18.inc
 
 LIC_FILES_CHKSUM ="file://COPYRIGHT;md5=9c5a05eab0ffc3590e50db38c51d1425"
 

--- a/recipes-devtools/rust/rustlib.bb
+++ b/recipes-devtools/rust/rustlib.bb
@@ -9,7 +9,7 @@ DEPENDS += "virtual/${TARGET_PREFIX}rust"
 RUSTLIB_DEP = ""
 
 do_install () {
-	for f in ${STAGING_DIR_NATIVE}/${rustlib_src}/*.so; do
+	for f in ${STAGING_DIR_NATIVE}/${rustlib_src}/*; do
 		echo Installing $f
 		install -D -m 755 $f ${D}/${rustlib}/$(basename $f)
 	done
@@ -21,4 +21,6 @@ python do_qa_configure() {
 }
 
 FILES_${PN} += "${rustlib}/*.so"
+FILES_${PN}-dev += "${rustlib}/*.rlib"
+FILES_${PN}-staticdev += "${rustlib}/*.a"
 FILES_${PN}-dbg += "${rustlib}/.debug"


### PR DESCRIPTION
Most importantly, update the stage0 snapshot so that it actually accomplishes something.  Additionally, improve support for running on tiny Linux systems with support for musl libc and static linking.